### PR TITLE
Move addDataSourceChangedDelegate from awakeWithContext to willActivate

### DIFF
--- a/WCApplicationContext Extension/InterfaceController.swift
+++ b/WCApplicationContext Extension/InterfaceController.swift
@@ -16,12 +16,12 @@ class InterfaceController: WKInterfaceController, DataSourceChangedDelegate {
     
     override func awakeWithContext(context: AnyObject?) {
         super.awakeWithContext(context)
-        
-        WatchSessionManager.sharedManager.addDataSourceChangedDelegate(self)
     }
 
     override func willActivate() {
-        // This method is called when watch view controller is about to be visible to user
+        
+        WatchSessionManager.sharedManager.addDataSourceChangedDelegate(self)
+        
         super.willActivate()
     }
 


### PR DESCRIPTION
The delegate is being removed in didDeactivate and will never be added again. This is not an issue in your example but will lead into missing UI updates when having more than one Interface Controller in the Watch App.
